### PR TITLE
fix: add Vesktop support

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,7 +48,7 @@ func main() {
 			time.Sleep(longSleep)
 			continue
 		}
-		if !isRunning("Discord") {
+		if !isRunning("Discord") && !isRunning("Vesktop") {
 			log.WithField("sleep", longSleep).Warn("Discord is not running")
 			ac.stop()
 			time.Sleep(longSleep)


### PR DESCRIPTION
This PR additionally checks if [Vesktop](https://github.com/Vencord/Vesktop) is running when checking for Discord status.